### PR TITLE
Move Linked List to its own file

### DIFF
--- a/src/main/java/dev/mccue/resolve/util/LL.java
+++ b/src/main/java/dev/mccue/resolve/util/LL.java
@@ -1,0 +1,54 @@
+package dev.mccue.resolve.util;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/*
+ * Basic Immutable Linked List Implementation.
+ */
+public sealed interface LL<T> {
+    record Nil<T>() implements LL<T> {
+        @Override
+        public Optional<T> headOption() {
+            return Optional.empty();
+        }
+    }
+    record Cons<T>(T head, LL<T> tail) implements LL<T> {
+        public Cons {
+            Objects.requireNonNull(head, "head must not be null");
+            Objects.requireNonNull(tail, "tail must not be null");
+        }
+
+        @Override
+        public Optional<T> headOption() {
+            return Optional.of(head);
+        }
+    }
+
+    default LL.Cons<T> prepend(T first) {
+        return new LL.Cons<>(first, this);
+    }
+
+    Optional<T> headOption();
+
+    static <T> LL<T> fromJavaList(List<T> list) {
+        LL<T> head = new LL.Nil<>();
+        for (int i = list.size() - 1; i >= 0; i--) {
+            head = new LL.Cons<>(
+                    list.get(i),
+                    head
+            );
+        }
+        return head;
+    }
+
+    default Cons<T> assumeNotEmpty() {
+        if (!(this instanceof LL.Cons<T> cons)) {
+            throw new IllegalStateException("Assumed to be not empty");
+        }
+        else {
+            return cons;
+        }
+    }
+}

--- a/src/test/java/dev/mccue/resolve/maven/PomParserTest.java
+++ b/src/test/java/dev/mccue/resolve/maven/PomParserTest.java
@@ -135,7 +135,7 @@ public final class PomParserTest {
                 pomParser
         );
 
-        var project = pomParser.state.project();
+        var project = pomParser.project();
 
         assertEquals(new Organization("dev.mccue"), project.module().organization());
         assertEquals(new ModuleName("resolve"), project.module().name());

--- a/src/test/java/dev/mccue/resolve/util/LLTest.java
+++ b/src/test/java/dev/mccue/resolve/util/LLTest.java
@@ -1,0 +1,116 @@
+package dev.mccue.resolve.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class LLTest {
+    @Test
+    public void testFromJavaList() {
+        var ll1 = LL.fromJavaList(List.of());
+        assertEquals(ll1, new LL.Nil<>());
+
+        var ll2 = LL.fromJavaList(List.of(1));
+        assertEquals(ll2, new LL.Cons<>(1, new LL.Nil<>()));
+
+        var ll3 = LL.fromJavaList(List.of(1, 2, 3, 4, 5));
+
+        assertEquals(ll3, new LL.Cons<>(
+                1,
+                new LL.Cons<>(
+                        2,
+                        new LL.Cons<>(
+                                3,
+                                new LL.Cons<>(4,
+                                        new LL.Cons<>(
+                                                5,
+                                                new LL.Nil<>()
+                                        )
+                                )
+                        )
+                )
+        ));
+    }
+
+    @Test
+    public void testAssumeNotEmpty() {
+        LL<?> ll1 = new LL.Nil<>();
+        assertThrows(
+                IllegalStateException.class,
+                ll1::assumeNotEmpty
+        );
+        LL<?> ll2 = new LL.Cons<>(1, new LL.Nil<>());
+        assertEquals(
+                ll2,
+                ll2.assumeNotEmpty()
+        );
+        assertEquals(
+                1,
+                ll2.assumeNotEmpty().head()
+        );
+    }
+
+    @Test
+    public void testHeadOption() {
+        LL<?> ll1 = new LL.Nil<>();
+        assertEquals(
+                Optional.empty(),
+                ll1.headOption()
+        );
+        LL<?> ll2 = new LL.Cons<>(1, new LL.Nil<>());
+        assertEquals(
+                Optional.of(1),
+                ll2.headOption()
+        );
+    }
+
+    @Test
+    public void assertThatItIsASealedInterfaceWithTwoRecordCases() {
+        assertTrue(
+                LL.class.isSealed()
+        );
+
+        assertTrue(
+                LL.class.isInterface()
+        );
+
+        assertEquals(
+                Set.of(LL.Cons.class, LL.Nil.class),
+                Set.copyOf(Arrays.asList(LL.class.getPermittedSubclasses()))
+        );
+
+        assertTrue(
+                LL.Nil.class.isRecord()
+        );
+
+        assertEquals(
+                0,
+                LL.Nil.class.getRecordComponents().length
+        );
+
+        assertTrue(
+                LL.Cons.class.isRecord()
+        );
+
+        assertEquals(
+                2,
+                LL.Cons.class.getRecordComponents().length
+        );
+
+        assertEquals(
+                "head",
+                LL.Cons.class.getRecordComponents()[0].getName()
+        );
+
+        assertEquals(
+                "tail",
+                LL.Cons.class.getRecordComponents()[1].getName()
+        );
+    }
+
+}


### PR DESCRIPTION
Moved the Linked list to the util package so we can use it whenever internals call for it.

My reasoning is
* If we implement the Ivy parser we might want to copy the implementation technique of pom parser a bit
* While we are still looking at arbitrary scala code there is a chance that we would want it for something else
* We aren't exposing `util` on the module path anyways so its nice for organization.