### PR TITLE
Round out Minimized exclusion implementation + Exclusion

### DIFF
--- a/src/main/java/dev/mccue/resolve/core/Activation.java
+++ b/src/main/java/dev/mccue/resolve/core/Activation.java
@@ -4,6 +4,9 @@ import dev.mccue.resolve.doc.Coursier;
 import dev.mccue.resolve.doc.Incomplete;
 import dev.mccue.resolve.util.Tuple2;
 
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/src/main/java/dev/mccue/resolve/core/Activation.java
+++ b/src/main/java/dev/mccue/resolve/core/Activation.java
@@ -4,9 +4,6 @@ import dev.mccue.resolve.doc.Coursier;
 import dev.mccue.resolve.doc.Incomplete;
 import dev.mccue.resolve.util.Tuple2;
 
-import java.net.Authenticator;
-import java.net.PasswordAuthentication;
-import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/src/main/java/dev/mccue/resolve/core/Dependency.java
+++ b/src/main/java/dev/mccue/resolve/core/Dependency.java
@@ -2,7 +2,6 @@ package dev.mccue.resolve.core;
 
 import dev.mccue.resolve.doc.Coursier;
 import dev.mccue.resolve.doc.Incomplete;
-import dev.mccue.resolve.util.Tuple2;
 
 import java.util.Objects;
 import java.util.Set;
@@ -58,7 +57,7 @@ public record Dependency(
                 module,
                 version,
                 Configuration.EMPTY,
-                MinimizedExclusions.ZERO,
+                MinimizedExclusions.NONE,
                 Publication.EMPTY,
                 false,
                 true

--- a/src/main/java/dev/mccue/resolve/core/Dependency.java
+++ b/src/main/java/dev/mccue/resolve/core/Dependency.java
@@ -69,7 +69,7 @@ public record Dependency(
             Module module,
             String version,
             Configuration configuration,
-            Set<Tuple2<Organization, ModuleName>> exclusions,
+            Set<Exclusion> exclusions,
             Attributes attributes,
             boolean optional,
             boolean transitive

--- a/src/main/java/dev/mccue/resolve/core/Exclusion.java
+++ b/src/main/java/dev/mccue/resolve/core/Exclusion.java
@@ -1,0 +1,15 @@
+package dev.mccue.resolve.core;
+
+import java.util.Objects;
+
+public record Exclusion(
+        Organization organization,
+        ModuleName moduleName
+) {
+    public static final Exclusion ALL = new Exclusion(Organization.ALL, ModuleName.ALL);
+
+    public Exclusion {
+        Objects.requireNonNull(organization, "organization must not be null");
+        Objects.requireNonNull(moduleName, "moduleName must not be null");
+    }
+}

--- a/src/main/java/dev/mccue/resolve/core/MinimizedExclusions.java
+++ b/src/main/java/dev/mccue/resolve/core/MinimizedExclusions.java
@@ -137,7 +137,8 @@ public final class MinimizedExclusions {
         ExclusionData join(ExclusionData other);
         ExclusionData meet(ExclusionData other);
 
-        Tuple4<Boolean,
+        Tuple4<
+                Boolean,
                 Set<Organization>,
                 Set<ModuleName>,
                 Set<Exclusion>
@@ -328,8 +329,8 @@ public final class MinimizedExclusions {
         @Override
         public ExclusionData meet(ExclusionData other) {
             return switch (other) {
-                case ExcludeNone __ -> this;
-                case ExcludeAll all -> all;
+                case ExcludeNone none -> none;
+                case ExcludeAll __ -> this;
                 case ExcludeSpecific excludeSpecific -> {
                     var otherByOrg = excludeSpecific.byOrg;
                     var otherByModule = excludeSpecific.byModuleName;
@@ -459,5 +460,12 @@ public final class MinimizedExclusions {
         else {
             return this.hash;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "MinimizedExclusions[" +
+                "exclusionData=" + exclusionData +
+                ']';
     }
 }

--- a/src/main/java/dev/mccue/resolve/maven/PomParser.java
+++ b/src/main/java/dev/mccue/resolve/maven/PomParser.java
@@ -115,7 +115,7 @@ public final class PomParser extends DefaultHandler {
         Configuration dependencyScope = Configuration.EMPTY;
         Type dependencyType = Type.EMPTY;
         Classifier dependencyClassifier = Classifier.EMPTY;
-        final HashSet<Tuple2<Organization, ModuleName>> dependencyExclusions = new HashSet<>();
+        final HashSet<Exclusion> dependencyExclusions = new HashSet<>();
 
         Organization dependencyExclusionGroupId = Organization.ALL;
         ModuleName dependencyExclusionArtifactId = ModuleName.ALL;
@@ -349,7 +349,7 @@ public final class PomParser extends DefaultHandler {
                     @Override
                     public void end(State state) {
                         state.dependencyExclusions.add(
-                               new Tuple2<>(
+                               new Exclusion(
                                        state.dependencyExclusionGroupId,
                                        state.dependencyExclusionArtifactId
                                )

--- a/src/test/java/dev/mccue/resolve/core/MinimizedExclusionsTest.java
+++ b/src/test/java/dev/mccue/resolve/core/MinimizedExclusionsTest.java
@@ -10,12 +10,12 @@ import static org.junit.jupiter.api.Assertions.*;
 public final class MinimizedExclusionsTest {
     @Test
     public void emptyExclusionsToSet() {
-        assertEquals(MinimizedExclusions.ZERO.toSet(), Set.of());
+        assertEquals(MinimizedExclusions.NONE.toSet(), Set.of());
     }
 
     @Test
     public void allExclusionsToSet() {
-        assertEquals(MinimizedExclusions.ONE.toSet(), Set.of(
+        assertEquals(MinimizedExclusions.ALL.toSet(), Set.of(
                 new Exclusion(Organization.ALL, ModuleName.ALL)
         ));
     }
@@ -92,14 +92,14 @@ public final class MinimizedExclusionsTest {
 
     @Test
     public void excludeAllExcludesAll() {
-        assertFalse(MinimizedExclusions.ONE.shouldInclude(new Organization("facebook"), new ModuleName("metaverse")));
-        assertFalse(MinimizedExclusions.ONE.shouldInclude(new Organization("abc"), new ModuleName("def")));
+        assertFalse(MinimizedExclusions.ALL.shouldInclude(new Organization("facebook"), new ModuleName("metaverse")));
+        assertFalse(MinimizedExclusions.ALL.shouldInclude(new Organization("abc"), new ModuleName("def")));
     }
 
     @Test
     public void excludeNoneExcludesNone() {
-        assertTrue(MinimizedExclusions.ZERO.shouldInclude(new Organization("facebook"), new ModuleName("metaverse")));
-        assertTrue(MinimizedExclusions.ZERO.shouldInclude(new Organization("abc"), new ModuleName("def")));
+        assertTrue(MinimizedExclusions.NONE.shouldInclude(new Organization("facebook"), new ModuleName("metaverse")));
+        assertTrue(MinimizedExclusions.NONE.shouldInclude(new Organization("abc"), new ModuleName("def")));
     }
 
     @Test
@@ -138,20 +138,20 @@ public final class MinimizedExclusionsTest {
     @Test
     public void meetWithNone() {
         assertEquals(
-                MinimizedExclusions.ZERO,
+                MinimizedExclusions.NONE,
                 MinimizedExclusions.of(List.of(
                         new Exclusion(new Organization("abc"), new ModuleName("def"))
-                )).meet(MinimizedExclusions.ZERO)
+                )).meet(MinimizedExclusions.NONE)
         );
 
         assertEquals(
-                MinimizedExclusions.ZERO,
-                MinimizedExclusions.ONE.meet(MinimizedExclusions.ZERO)
+                MinimizedExclusions.NONE,
+                MinimizedExclusions.ALL.meet(MinimizedExclusions.NONE)
         );
 
         assertEquals(
-                MinimizedExclusions.ZERO,
-                MinimizedExclusions.ZERO.meet(MinimizedExclusions.ZERO)
+                MinimizedExclusions.NONE,
+                MinimizedExclusions.NONE.meet(MinimizedExclusions.NONE)
         );
     }
 }

--- a/src/test/java/dev/mccue/resolve/core/MinimizedExclusionsTest.java
+++ b/src/test/java/dev/mccue/resolve/core/MinimizedExclusionsTest.java
@@ -2,9 +2,10 @@ package dev.mccue.resolve.core;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class MinimizedExclusionsTest {
     @Test
@@ -89,4 +90,68 @@ public final class MinimizedExclusionsTest {
         );
     }
 
+    @Test
+    public void excludeAllExcludesAll() {
+        assertFalse(MinimizedExclusions.ONE.shouldInclude(new Organization("facebook"), new ModuleName("metaverse")));
+        assertFalse(MinimizedExclusions.ONE.shouldInclude(new Organization("abc"), new ModuleName("def")));
+    }
+
+    @Test
+    public void excludeNoneExcludesNone() {
+        assertTrue(MinimizedExclusions.ZERO.shouldInclude(new Organization("facebook"), new ModuleName("metaverse")));
+        assertTrue(MinimizedExclusions.ZERO.shouldInclude(new Organization("abc"), new ModuleName("def")));
+    }
+
+    @Test
+    public void excludeSpecificDep() {
+        var excl = MinimizedExclusions.of(List.of(
+                        new Exclusion(new Organization("facebook"), new ModuleName("metaverse"))
+        ));
+        assertFalse(excl.shouldInclude(new Organization("facebook"), new ModuleName("metaverse")));
+        assertTrue(excl.shouldInclude(new Organization("abc"), new ModuleName("def")));
+        assertTrue(excl.shouldInclude(new Organization("facebook"), new ModuleName("def")));
+        assertTrue(excl.shouldInclude(new Organization("abc"), new ModuleName("metaverse")));
+    }
+
+    @Test
+    public void excludeAllWithArtifact() {
+        var excl = MinimizedExclusions.of(List.of(
+                new Exclusion(new Organization("*"), new ModuleName("metaverse"))
+        ));
+        assertFalse(excl.shouldInclude(new Organization("facebook"), new ModuleName("metaverse")));
+        assertFalse(excl.shouldInclude(new Organization("google"), new ModuleName("metaverse")));
+        assertTrue(excl.shouldInclude(new Organization("abc"), new ModuleName("def")));
+        assertTrue(excl.shouldInclude(new Organization("facebook"), new ModuleName("def")));
+    }
+
+    @Test
+    public void excludeAllInGroup() {
+        var excl = MinimizedExclusions.of(List.of(
+                new Exclusion(new Organization("google"), new ModuleName("*"))
+        ));
+        assertFalse(excl.shouldInclude(new Organization("google"), new ModuleName("guice")));
+        assertFalse(excl.shouldInclude(new Organization("google"), new ModuleName("guava")));
+        assertTrue(excl.shouldInclude(new Organization("facebook"), new ModuleName("guice")));
+        assertTrue(excl.shouldInclude(new Organization("abc"), new ModuleName("metaverse")));
+    }
+
+    @Test
+    public void meetWithNone() {
+        assertEquals(
+                MinimizedExclusions.ZERO,
+                MinimizedExclusions.of(List.of(
+                        new Exclusion(new Organization("abc"), new ModuleName("def"))
+                )).meet(MinimizedExclusions.ZERO)
+        );
+
+        assertEquals(
+                MinimizedExclusions.ZERO,
+                MinimizedExclusions.ONE.meet(MinimizedExclusions.ZERO)
+        );
+
+        assertEquals(
+                MinimizedExclusions.ZERO,
+                MinimizedExclusions.ZERO.meet(MinimizedExclusions.ZERO)
+        );
+    }
 }

--- a/src/test/java/dev/mccue/resolve/core/MinimizedExclusionsTest.java
+++ b/src/test/java/dev/mccue/resolve/core/MinimizedExclusionsTest.java
@@ -1,0 +1,92 @@
+package dev.mccue.resolve.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public final class MinimizedExclusionsTest {
+    @Test
+    public void emptyExclusionsToSet() {
+        assertEquals(MinimizedExclusions.ZERO.toSet(), Set.of());
+    }
+
+    @Test
+    public void allExclusionsToSet() {
+        assertEquals(MinimizedExclusions.ONE.toSet(), Set.of(
+                new Exclusion(Organization.ALL, ModuleName.ALL)
+        ));
+    }
+
+    @Test
+    public void regularExclusionsToSet() {
+        var exclusions = MinimizedExclusions.of(Set.of(
+                new Exclusion(new Organization("apple"), ModuleName.ALL),
+                new Exclusion(Organization.ALL, new ModuleName("metaverse")),
+                new Exclusion(new Organization("com.google"), new ModuleName("abc"))
+        ));
+
+        assertEquals(exclusions.toSet(), Set.of(
+                new Exclusion(new Organization("apple"), ModuleName.ALL),
+                new Exclusion(Organization.ALL, new ModuleName("metaverse")),
+                new Exclusion(new Organization("com.google"), new ModuleName("abc"))
+        ));
+    }
+
+    @Test
+    public void allModuleExclusionsReplaceMoreSpecificExclusions() {
+        assertEquals(
+                MinimizedExclusions.of(Set.of(
+                        new Exclusion(new Organization("facebook"), new ModuleName("metaverse")),
+                        new Exclusion(new Organization("facebook"), ModuleName.ALL)
+                )).toSet(),
+                Set.of(new Exclusion(new Organization("facebook"), ModuleName.ALL))
+        );
+    }
+
+    @Test
+    public void allOrganizationExclusionsReplaceMoreSpecificExclusions() {
+        assertEquals(
+                MinimizedExclusions.of(Set.of(
+                        new Exclusion(Organization.ALL, new ModuleName("metaverse")),
+                        new Exclusion(new Organization("facebook"), new ModuleName("metaverse")),
+                        new Exclusion(new Organization("facebook"), new ModuleName("whatever"))
+                )).toSet(),
+                Set.of(
+                        new Exclusion(Organization.ALL, new ModuleName("metaverse")),
+                        new Exclusion(new Organization("facebook"), new ModuleName("whatever"))
+                )
+        );
+    }
+
+    @Test
+    public void joiningWithAllExclusionsGetsJustAllExclusions() {
+        assertEquals(
+                MinimizedExclusions.of(Set.of(Exclusion.ALL)),
+                MinimizedExclusions.of(Set.of(Exclusion.ALL)).join(
+                    MinimizedExclusions.of(
+                            Set.of(
+                                    new Exclusion(new Organization("facebook"), new ModuleName("metaverse")),
+                                    new Exclusion(new Organization("facebook"), new ModuleName("whatever"))
+                            )
+                    )
+                )
+        );
+
+        assertEquals(
+                MinimizedExclusions.of(Set.of(Exclusion.ALL)),
+                MinimizedExclusions.of(
+                        Set.of(
+                                new Exclusion(new Organization("facebook"), new ModuleName("metaverse")),
+                                new Exclusion(new Organization("facebook"), new ModuleName("whatever"))
+                        )
+                ).join(
+                        MinimizedExclusions.of(Set.of(
+                                new Exclusion(Organization.ALL, ModuleName.ALL)
+                        ))
+                )
+        );
+    }
+
+}


### PR DESCRIPTION
* Finishes the translation of `MinimizedExclusion`s
* Replaces `Tuple2<Organization, ModuleName>` with a named `Exclusion`.

Note: I'm not convinced that even coursier [has this right](https://github.com/coursier/coursier/issues/2549) and its kinda hard to test until we are using it in a resolution. 

